### PR TITLE
handle case where SolrResponse data doesn't have "response" or "grouped" key

### DIFF
--- a/SolrClient/solrresp.py
+++ b/SolrClient/solrresp.py
@@ -19,6 +19,9 @@ class SolrResponse:
                 self.groups[field + '_ngroups'] = data['grouped'][field]['ngroups']
                 self.groups[field + '_matches'] = data['grouped'][field]['matches']
                 self.docs = data['grouped'][field]['groups']
+        else:
+            self.grouped = False
+            self.docs = {}
         
         for doc in self.docs:
             for field in doc:


### PR DESCRIPTION
For example, the [Suggester](https://wiki.apache.org/solr/Suggester) component returns data under the "suggest" key instead of "response" or "grouped", which caused the SolrResponse constructor to raise an error when looping over self.docs.

(Same as #19 except merging into the dev branch.)