### PR TITLE
Adds SolrClient.delete_doc_by_query()

### DIFF
--- a/SolrClient/solrclient.py
+++ b/SolrClient/solrclient.py
@@ -42,7 +42,7 @@ class SolrClient:
         :param bool openSearcher: If new searcher is to be opened
         :param bool softCommit: SoftCommit
         :param bool waitServer: Blocks until the new searcher is opened
-        :param book commit: Commit
+        :param bool commit: Commit
 
         Sends a commit to a Solr collection.
 
@@ -132,6 +132,24 @@ class SolrClient:
         if ' ' in doc_id:
             doc_id = '"{}"'.format(doc_id)
         temp = {"delete": {"query": 'id:{}'.format(doc_id)}}
+        resp, con_inf = self.transport.send_request(method='POST',
+                                                    endpoint='update',
+                                                    collection=collection,
+                                                    data=json.dumps(temp),
+                                                    *kwargs)
+        return resp
+
+    def delete_doc_by_query(self, collection, query, **kwargs):
+        '''
+        :param str collection: The name of the collection for the request
+        :param str query: Query selecting documents to be deleted.
+
+        Deletes items from Solr based on a given query. ::
+
+            >>> solr.delete_doc_by_query('SolrClient_unittest','*:*')
+
+        '''
+        temp = {"delete": {"query": query}}
         resp, con_inf = self.transport.send_request(method='POST',
                                                     endpoint='update',
                                                     collection=collection,

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -60,6 +60,22 @@ class ClientTestIndexing(unittest.TestCase):
                                 {'q': 'id:"potato potato"'}).docs) == 0)
         self.delete_docs()
 
+    def test_delete_doc_by_query(self):
+        self.delete_docs()
+        self.solr.index_json(test_config['SOLR_COLLECTION'], json.dumps(
+                        [{'id': 'potato potato', 'product_name': 'potato'}]))
+        self.commit()
+        self.assertTrue(
+            len(self.solr.query(test_config['SOLR_COLLECTION'],
+                                {'q': 'id:"potato potato"'}).docs) == 1)
+        self.solr.delete_doc_by_query(test_config['SOLR_COLLECTION'],
+                                      "product_name:potato")
+        self.commit()
+        self.assertTrue(
+            len(self.solr.query(test_config['SOLR_COLLECTION'],
+                                {'q': 'id:"potato potato"'}).docs) == 0)
+        self.delete_docs()
+
     @unittest.skip("Skipping for now")
     def test_access_without_auth(self):
         if not test_config['SOLR_CREDENTIALS'][0]:


### PR DESCRIPTION
Thanks for sharing this Solr client - I love that it's built on `requests` and supports cursors :)

I wanted a more general purpose document delete function: I've tested it against my own Solr instance but haven't run the new unit test.  If you're interested in merging and you need me to run the unit tests myself I'll see if I can follow the [instructions](https://github.com/moonlitesolutions/SolrClient/blob/master/test/README.md).

Further, if you prefer, I can rewrite `delete_doc_by_id()` in terms of the more general function.