### PR TITLE
Use POST for long queries

### DIFF
--- a/SolrClient/solrclient.py
+++ b/SolrClient/solrclient.py
@@ -85,7 +85,28 @@ class SolrClient:
                 elif type(query[field]) is list:
                     query[field] = [s.replace(' ','') for s in query[field]]
 
-        resp, con_inf = self.transport.send_request(method='GET',endpoint=request_handler,collection=collection, params=query,*kwargs)
+        # If the query is long, use POST instead of GET. Estimate query string
+        # length by converting the query dict to a string since at this point
+        # we don't have a urlencoded query yet.
+        if len(str(query)) > 1000:
+            method = 'POST'
+            headers = {'content-type': 'application/x-www-form-urlencoded'}
+            params = {}
+            data = query
+        else:
+            method = 'GET'
+            headers = None
+            params = query
+            data = {}
+
+        resp, con_inf = self.transport.send_request(method=method,
+                                                    endpoint=request_handler,
+                                                    collection=collection,
+                                                    params=params,
+                                                    data=data,
+                                                    headers=headers,
+                                                    *kwargs)
+
         if resp:
             resp = SolrResponse(resp)
             resp.url = con_inf['url']

--- a/SolrClient/transport/transportrequests.py
+++ b/SolrClient/transport/transportrequests.py
@@ -41,12 +41,14 @@ class TransportRequests(TransportBase):
         else:
             raise ValueError("No URL 'endpoint' set in parameters to send_request")
 
+        headers = kwargs.get('headers') or {'content-type': 'application/json'}
+
         self.logger.debug("Sending Request to {} with {}".format(url,", ".join([str("{}={}".format(key, params[key])) for key in params])))
 
         #Some code used from ES python client.
         start = time.time()
         try:
-            res = self.session.request(method, url, params=params, data=data,headers = {'content-type': 'application/json'})
+            res = self.session.request(method, url, params=params, data=data, headers=headers)
             duration = time.time() - start
             self.logger.debug("Request Completed in {} Seconds".format(round(duration,2)))
         except requests.exceptions.SSLError as e:


### PR DESCRIPTION
I have a handful of very long queries so I modified my fork like so after looking at:

* https://github.com/django-haystack/pysolr/blob/master/pysolr.py#L415
* http://stackoverflow.com/questions/2997014/can-you-use-post-to-run-a-query-in-solr-select

Obviously pysolr handles this slightly better in that it checks the urlencoded string length, but even so, I don't find any really compelling reason to do better than estimate the query length.

Let me know what you think of this modification.  I've tested it on my Solr instance with all the queries we run.