### PR TITLE
moved router to transport

### DIFF
--- a/SolrClient/solrclient.py
+++ b/SolrClient/solrclient.py
@@ -2,7 +2,6 @@ import gzip
 import os
 import json
 import logging
-from .routers.plain import PlainRouter
 from .transport import TransportRequests
 from .exceptions import NotFoundError
 from .schema import Schema
@@ -26,15 +25,12 @@ class SolrClient(object):
                  devel=False,
                  auth=None,
                  log=None,
-                 router=PlainRouter,
                  **kwargs):
         self.devel = devel
-        self.host = host
-        self.transport = transport(self, auth=auth, devel=devel)
+        self.transport = transport(self, auth=auth, devel=devel, host=host, **kwargs)
         self.logger = log if log else logging.getLogger(__package__)
         self.schema = Schema(self)
         self.collections = Collections(self, self.logger)
-        self.router = router(self, host, **kwargs)
 
     def get_zk(self):
         return ZK(self, self.logger)

--- a/SolrClient/transport/transportbase.py
+++ b/SolrClient/transport/transportbase.py
@@ -1,5 +1,6 @@
 import logging
 from ..exceptions import *
+from ..routers.plain import PlainRouter
 
 
 class TransportBase():
@@ -7,13 +8,14 @@ class TransportBase():
     Base Transport Class
     """
 
-    def __init__(self, solr, auth=(None, None), devel=None):
+    def __init__(self, solr, auth=(None, None), devel=None, host=None, router=PlainRouter, **kwargs):
         self.logger = logging.getLogger(str(__package__))
         self.auth = auth
         self._devel = devel
         self._action_log = []
         self._action_log_count = 1000
         self.solr = solr
+        self.router = router(self, host, **kwargs)
         self.setup()
 
     def _add_to_action(self, action):
@@ -29,7 +31,7 @@ class TransportBase():
 
         def inner(self, **kwargs):
             last_exception = None
-            for host in self.solr.router.get_hosts(**kwargs):
+            for host in self.router.get_hosts(**kwargs):
                 try:
                     return function(self, host, **kwargs)
                 except SolrError as e:


### PR DESCRIPTION
You meant like this ?

I still get 1 failing test on reindexer but I don't think it's connected to this change:

```
======================================================================
FAIL: test_ignore_fields (test.test_reindexer.ReindexerTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/vagrant/solr_client/test/test_reindexer.py", line 127, in test_ignore_fields
    self.assertTrue(field in reindexer._ignore_fields)
AssertionError: False is not true
```