### PR TITLE
Fixed indexing error in SolrClient

### DIFF
--- a/SolrClient/solrclient.py
+++ b/SolrClient/solrclient.py
@@ -139,7 +139,7 @@ class SolrClient:
 
         """
         data = json.dumps(docs)
-        return self.index(collection, data, params, **kwargs)
+        return self.index_json(collection, data, params, **kwargs)
 
     def index_json(self, collection, data, params=None, **kwargs):
         """


### PR DESCRIPTION
The non-json indexing function was calling itself infinitely.