### PR TITLE
Update kazoo version to make it compatible with Python 3.7

### DIFF
--- a/SolrClient/__init__.py
+++ b/SolrClient/__init__.py
@@ -7,4 +7,4 @@ from .collections import Collections
 from .zk import ZK
 #This is the main project version. On new releases, it only needs to be updated here and in the README.md.
 #Documentation and setup.py will pull from here.
-__version__ = '0.2.0'
+__version__ = '0.3.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-kazoo==2.2.1
+kazoo==2.6.1
 tox==2.3.1
 requests>=2.2.1
 mmh3>=2.3.1

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,6 @@ setup(
     description = "Python based client for Solr. ",
     install_requires = [
         "requests>=2.2.1",
-        "kazoo==2.2.1",
+        "kazoo==2.6.1",
     ]
 )


### PR DESCRIPTION
This also bumps the SolrClient version to 0.3.0. 