### PR TITLE
Usability Fixes for Large Loads

### DIFF
--- a/SolrClient/__init__.py
+++ b/SolrClient/__init__.py
@@ -7,4 +7,4 @@ from .collections import Collections
 from .zk import ZK
 #This is the main project version. On new releases, it only needs to be updated here and in the README.md.
 #Documentation and setup.py will pull from here.
-__version__ = '0.3.0'
+__version__ = '0.3.1'

--- a/SolrClient/transport/transportrequests.py
+++ b/SolrClient/transport/transportrequests.py
@@ -47,7 +47,7 @@ class TransportRequests(TransportBase):
         # Some code used from ES python client.
         start = time.time()
         try:
-            res = self.session.request(method, url, params=params, data=data, headers=headers)
+            res = self.session.request(method, url, params=params, data=data, headers=headers, verify=False)
             duration = time.time() - start
             self.logger.debug("Request Completed in {} Seconds".format(round(duration, 2)))
         except requests.exceptions.SSLError as e:


### PR DESCRIPTION
* Disables SSL verification so it can be used with self-signed certificates etc.
* Adds a parameter to remove complete files after they are loaded to Solr to prevent out-of-disk errors when processing large amounts of data.